### PR TITLE
Added :empty option for existing elements with no content

### DIFF
--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -432,8 +432,7 @@ module ROXML # :nodoc:
       # === Other Options
       # [:in] An optional name of a wrapping tag for this XML accessor.
       #       This can include other xpath values, which will be joined with :from with a '/'
-      # [:else] Default value for attribute, if missing from the xml on .from_xml
-      # [:empty] Default value for attribute, if attribute is present but contains no content. e.g. <name />
+      # [:else] Default value for attribute, if missing from the xml (or it's there but its contents are blank) on .from_xml
       # [:required] If true, throws RequiredElementMissing when the element isn't present
       # [:frozen] If true, all results are frozen (using #freeze) at parse-time.
       # [:cdata] true for values which should be input from or output as cdata elements

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -433,6 +433,7 @@ module ROXML # :nodoc:
       # [:in] An optional name of a wrapping tag for this XML accessor.
       #       This can include other xpath values, which will be joined with :from with a '/'
       # [:else] Default value for attribute, if missing from the xml on .from_xml
+      # [:empty] Default value for attribute, if attribute is present but contains no content. e.g. <name />
       # [:required] If true, throws RequiredElementMissing when the element isn't present
       # [:frozen] If true, all results are frozen (using #freeze) at parse-time.
       # [:cdata] true for values which should be input from or output as cdata elements

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -15,14 +15,13 @@ module ROXML
   end
 
   class Definition # :nodoc:
-    attr_reader :accessor, :attr_name, :blocks, :empty, :hash, :name, :namespace, :sought_type, :to_xml, :wrapper
-    bool_attr_reader :array, :cdata, :frozen, :name_explicit, :required
+    attr_reader :name, :sought_type, :wrapper, :hash, :blocks, :accessor, :to_xml, :attr_name, :namespace
+    bool_attr_reader :name_explicit, :array, :cdata, :required, :frozen
 
     def initialize(sym, opts = {}, &block)
       opts.assert_valid_keys(:from, :in, :as, :namespace,
-                             :else, :empty, :required, :frozen, :cdata, :to_xml)
+                             :else, :required, :frozen, :cdata, :to_xml)
       @default = opts.delete(:else)
-      @empty = opts.delete(:empty)
       @to_xml = opts.delete(:to_xml)
       @name_explicit = opts.has_key?(:from) && opts[:from].is_a?(String)
       @cdata = opts.delete(:cdata)
@@ -109,7 +108,7 @@ module ROXML
       end
       @default.duplicable? ? @default.dup : @default
     end
-    
+
     def to_ref(inst)
       case sought_type
       when :attr          then XMLAttributeRef

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -15,13 +15,14 @@ module ROXML
   end
 
   class Definition # :nodoc:
-    attr_reader :name, :sought_type, :wrapper, :hash, :blocks, :accessor, :to_xml, :attr_name, :namespace
-    bool_attr_reader :name_explicit, :array, :cdata, :required, :frozen
+    attr_reader :accessor, :attr_name, :blocks, :empty, :hash, :name, :namespace, :sought_type, :to_xml, :wrapper
+    bool_attr_reader :array, :cdata, :frozen, :name_explicit, :required
 
     def initialize(sym, opts = {}, &block)
       opts.assert_valid_keys(:from, :in, :as, :namespace,
-                             :else, :required, :frozen, :cdata, :to_xml)
+                             :else, :empty, :required, :frozen, :cdata, :to_xml)
       @default = opts.delete(:else)
+      @empty = opts.delete(:empty)
       @to_xml = opts.delete(:to_xml)
       @name_explicit = opts.has_key?(:from) && opts[:from].is_a?(String)
       @cdata = opts.delete(:cdata)
@@ -108,7 +109,7 @@ module ROXML
       end
       @default.duplicable? ? @default.dup : @default
     end
-
+    
     def to_ref(inst)
       case sought_type
       when :attr          then XMLAttributeRef

--- a/lib/roxml/xml/references.rb
+++ b/lib/roxml/xml/references.rb
@@ -7,7 +7,7 @@ module ROXML
   #
   class XMLRef # :nodoc:
     attr_reader :opts
-    delegate :required?, :array?, :accessor, :default, :wrapper, :to => :opts
+    delegate :accessor, :array?, :default, :empty, :required?, :wrapper, :to => :opts
 
     def initialize(opts, instance)
       @opts = opts
@@ -34,8 +34,13 @@ module ROXML
     def value_in(xml)
       xml = XML::Node.from(xml)
       value = fetch_value(xml)
-      value = default if value.nil?
 
+      if value.nil?
+        value = default
+      elsif empty && value.to_s.empty?
+        value = empty
+      end
+      
       freeze(apply_blocks(value))
     end
 

--- a/lib/roxml/xml/references.rb
+++ b/lib/roxml/xml/references.rb
@@ -7,7 +7,7 @@ module ROXML
   #
   class XMLRef # :nodoc:
     attr_reader :opts
-    delegate :accessor, :array?, :default, :empty, :required?, :wrapper, :to => :opts
+    delegate :required?, :array?, :accessor, :default, :wrapper, :to => :opts
 
     def initialize(opts, instance)
       @opts = opts
@@ -34,13 +34,8 @@ module ROXML
     def value_in(xml)
       xml = XML::Node.from(xml)
       value = fetch_value(xml)
+      value = default if value.nil? || value.to_s.empty?
 
-      if value.nil?
-        value = default
-      elsif empty && value.to_s.empty?
-        value = empty
-      end
-      
       freeze(apply_blocks(value))
     end
 

--- a/test/unit/definition_test.rb
+++ b/test/unit/definition_test.rb
@@ -171,19 +171,14 @@ class TestDefinition < ActiveSupport::TestCase
     assert_equal RoxmlObject, ROXML::Definition.new(:types, :as => [RoxmlObject]).sought_type
   end
 
-  def test_default_works
+  def test_default_for_missing_element_works
     opts = ROXML::Definition.new(:missing, :else => true)
     assert_equal true, opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml></xml>'))
   end
 
-  def test_empty_works
-    opts = ROXML::Definition.new(:age, :empty => 50)
-    assert_equal 50, opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml><age /></xml>'))
-  end
-
-  def test_else_comes_before_empty_works
-    opts = ROXML::Definition.new(:missing, :else => 25, :empty => 50)
-    assert_equal 25, opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml></xml>'))
+  def test_default_for_empty_element_works
+    opts = ROXML::Definition.new(:age, :else => 25)
+    assert_equal 25, opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml><age /></xml>'))
   end
 
   def test_default_works_for_arrays

--- a/test/unit/definition_test.rb
+++ b/test/unit/definition_test.rb
@@ -176,6 +176,16 @@ class TestDefinition < ActiveSupport::TestCase
     assert_equal true, opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml></xml>'))
   end
 
+  def test_empty_works
+    opts = ROXML::Definition.new(:age, :empty => 50)
+    assert_equal 50, opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml><age /></xml>'))
+  end
+
+  def test_else_comes_before_empty_works
+    opts = ROXML::Definition.new(:missing, :else => 25, :empty => 50)
+    assert_equal 25, opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml></xml>'))
+  end
+
   def test_default_works_for_arrays
     opts = ROXML::Definition.new(:missing, :as => [])
     assert_equal [], opts.to_ref(RoxmlObject.new).value_in(ROXML::XML.parse_string('<xml></xml>'))


### PR DESCRIPTION
As you know, the :else options is useful when an element is not in the XML at all. For example:

```
<person>
</person>

xml_accessor :name, :else => "None given"
```

I've added an option which handles a situation where the XML is something like this:

```
<person>
  <name />
</person>
```

As you can see, the element is there, it just has no content, which is different to the previous example.

My change allows me to do this:

```
xml_accessor :name, :empty => "None given"
```

Of course, you can combine the two:

```
xml_accessor :name, :else => "None given", :empty => "An empty string"
```

The reason why I called it empty is to match the Ruby "".empty? method. 

I needed this because I had numerous places where I was checking for nil? The XML that I was consuming had many elements with no content. Now I can avoid those nil? checks using :empty.
