### PR TITLE
Allow ':as => :text' to override coerced values.

### DIFF
--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -212,7 +212,7 @@ module ROXML
         as = (block ? :bool_combined : :bool_standalone)
       end
       as = self.class.block_shorthands.fetch(as) do
-        unless as.respond_to?(:from_xml) || (as.respond_to?(:first) && as.first.respond_to?(:from_xml)) || (as.is_a?(Hash) && !(as.keys & [:key, :value]).empty?)
+        unless (as == :text) || as.respond_to?(:from_xml) || (as.respond_to?(:first) && as.first.respond_to?(:from_xml)) || (as.is_a?(Hash) && !(as.keys & [:key, :value]).empty?)
           raise ArgumentError, "Invalid :as argument #{as}" unless as.nil?
         end
         nil


### PR DESCRIPTION
Some data is automatically coerced into certain data types.  For example:
  xml_accessor :created_at

This will automatically create a datetime.  This is not always desired, and there is no way around this right now.

My patch allows you to specify an ":as => :text" to an xml_accessor to force the attribute to be a string.

I've been using this in production for over a year, and thought I sent a pull request already, but I didn't.  

Hope you pull it.  Thanks.
