### PR TITLE
Fix reading of VERSION file

### DIFF
--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -14,7 +14,7 @@ require 'roxml/definition'
 require 'roxml/xml'
 
 module ROXML # :nodoc:
-  VERSION = File.read('VERSION')
+  VERSION = File.read(File.expand_path("../../VERSION", __FILE__))
 
   def self.included(base) # :nodoc:
     base.class_eval do


### PR DESCRIPTION
If the cwd is not the project root, the latest release bombs with this error:

```
/Users/fijabakk/src/git/roxml/lib/roxml.rb:18:in `read': No such file or directory - VERSION (Errno::ENOENT)
    from /Users/fijabakk/src/git/roxml/lib/roxml.rb:18:in `<module:ROXML>'
    from /Users/fijabakk/src/git/roxml/lib/roxml.rb:16:in `<top (required)>'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/irb/init.rb:281:in `block in load_modules'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/irb/init.rb:279:in `each'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/irb/init.rb:279:in `load_modules'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/irb/init.rb:20:in `setup'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/irb.rb:53:in `start'
    from /Users/fijabakk/.rvm/rubies/ruby-1.9.2-p290/bin/irb:16:in `<main>'
```

This patch fixes the problem by reading the VERSION file relative to the current file.
