### PR TITLE
Fix reader to always return the same object

### DIFF
--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -480,10 +480,9 @@ module ROXML # :nodoc:
       def add_reader(attr)
         define_method(attr.accessor) do
           if instance_variable_get(attr.instance_variable_name).nil?
-            attr.default
-          else
-            instance_variable_get(attr.instance_variable_name)
+            instance_variable_set(attr.instance_variable_name, attr.default)
           end
+          instance_variable_get(attr.instance_variable_name)
         end
       end
     end

--- a/spec/examples/search_query_spec.rb
+++ b/spec/examples/search_query_spec.rb
@@ -15,6 +15,10 @@ describe SearchQuery do
 		@search.max_results == 20
 	end
 
+	it 'should return the same object for the default value' do
+		@search.language.object_id.should == @search.language.object_id
+	end
+
 	it 'should respect the defaults when loading from xml' do
 		@saved_search.language.should == 'EN'
 		@saved_search.max_results == 20


### PR DESCRIPTION
I was having some issues with default values for arrays.
The default value is always a dup object, so we need to set the instance variable otherwise we always have a new object.
