### PR TITLE
Namespacify all elements of an XPath, not just the first

### DIFF
--- a/spec/xml/namespace_spec.rb
+++ b/spec/xml/namespace_spec.rb
@@ -125,6 +125,18 @@ EOS
         @instance.default_namespace_with_namespacey_from.should == 'namespacey node'
       end
     end
+
+    context "with an namespacey XPath :from" do
+      it "should use the given namespace" do
+        @instance.default_namespace_with_namespacey_xpath_from.should == 'namespacey xpath node'
+      end
+    end
+
+    context "with an XPath :from" do
+      it "should use the default namespace" do
+        @instance.default_namespace_with_xpath_from.should == 'default namespace with xpath node'
+      end
+    end
   end
 
   context "with a default namespace declared" do
@@ -139,6 +151,8 @@ EOS
       xml_reader :default_namespace_with_namespaceless_from_and_explicit_namespace, :from => 'with_namespaceless_from', :namespace => 'explicit'
       xml_reader :default_namespace_with_namespaceless_from_and_namespace_false, :from => 'with_namespaceless_from', :namespace => false
       xml_reader :default_namespace_with_namespacey_from, :from => 'namespacey:with_namespacey_from'
+      xml_reader :default_namespace_with_namespacey_xpath_from, :from => 'xpath/namespacey:default_namespace'
+      xml_reader :default_namespace_with_xpath_from, :from => 'xpath/default_namespace'
 
       # These are handled in the "roxml namespacey declaration" shared spec
       # xml_reader :default_namespace_with_namespacey_from_and_namespace_false, :from => 'namespacey:with_namespaceless_from', :namespace => false
@@ -155,6 +169,8 @@ EOS
           <default_declared:with_namespaceless_from>default namespace node</default_declared:with_namespaceless_from>
           <explicit:default_and_explicit_namespace>explicit namespace node</explicit:default_and_explicit_namespace>
           <default_namespace_with_namespace_false>namespaceless node</default_namespace_with_namespace_false>
+          <default_declared:xpath><namespacey:default_namespace>namespacey xpath node</namespacey:default_namespace></default_declared:xpath>
+          <default_declared:xpath><default_declared:default_namespace>default namespace with xpath node</default_declared:default_namespace></default_declared:xpath>
         </book>
       })
     end
@@ -172,6 +188,8 @@ EOS
       xml_reader :default_namespace_with_namespaceless_from_and_explicit_namespace, :from => 'with_namespaceless_from', :namespace => 'explicit'
       xml_reader :default_namespace_with_namespaceless_from_and_namespace_false, :from => 'with_namespaceless_from', :namespace => false
       xml_reader :default_namespace_with_namespacey_from, :from => 'namespacey:with_namespacey_from'
+      xml_reader :default_namespace_with_namespacey_xpath_from, :from => 'xpath/namespacey:default_namespace'
+      xml_reader :default_namespace_with_xpath_from, :from => 'xpath/default_namespace'
 
       # These are handled in the "roxml namespacey declaration" shared spec
       # xml_reader :default_namespace_with_namespacey_from_and_namespace_false, :from => 'namespacey:with_namespaceless_from', :namespace => false
@@ -188,6 +206,8 @@ EOS
           <with_namespaceless_from>default namespace node</with_namespaceless_from>
           <explicit:default_and_explicit_namespace>explicit namespace node</explicit:default_and_explicit_namespace>
           <default_namespace_with_namespace_false xmlns="">namespaceless node</default_namespace_with_namespace_false>
+          <xpath><namespacey:default_namespace>namespacey xpath node</namespacey:default_namespace></xpath>
+          <xpath><default_namespace>default namespace with xpath node</default_namespace></xpath>
         </book>
       })
     end


### PR DESCRIPTION
I found that when a default namespace was present, specifying a deep XPath in :from was ineffective because the namespace was only being prepended to the whole XPath string and not each element. I was initially just going to `what.split("/")` but that would have broken more complex expressions so I avoided that problem with a scary-looking regular expression (basically ignoring anything in []). I also made the check for an existing namespace a little more careful in the process.
