### PR TITLE
inherit from ArgumentError rather than Exception

### DIFF
--- a/lib/roxml/xml/references.rb
+++ b/lib/roxml/xml/references.rb
@@ -1,5 +1,5 @@
 module ROXML
-  class RequiredElementMissing < Exception # :nodoc:
+  class RequiredElementMissing < ArgumentError # :nodoc:
   end
 
   #


### PR DESCRIPTION
Resolves #48 

This updates the error handling to follow best practices by not inheriting directly from Exception for a runtime problem.