### PR TITLE
Replace deprecated BigDecimal.new() calls with BigDecimal()

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    psych (3.0.0)
+    psych (3.1.0)
     public_suffix (3.0.1)
     rack (1.6.8)
     rake (0.9.6)

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -176,7 +176,7 @@ module ROXML
       CORE_BLOCK_SHORTHANDS.tap do |blocks|
         blocks.reverse_merge!(BigDecimal => lambda do |val|
           all(val) do |v|
-            BigDecimal.new(v) unless v.blank?
+            BigDecimal(v) unless v.blank?
           end
         end) if defined?(BigDecimal)
 

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -281,8 +281,8 @@ describe ROXML::Definition do
         it_should_behave_like "block shorthand type declaration"
 
         it "should translate text to decimal numbers" do
-          expect(@definition.blocks.first['3']).to eq(BigDecimal.new("3.0"))
-          expect(@definition.blocks.first['0.3']).to eq(BigDecimal.new("0.3"))
+          expect(@definition.blocks.first['3']).to eq(BigDecimal("3.0"))
+          expect(@definition.blocks.first['0.3']).to eq(BigDecimal("0.3"))
         end
 
         # Ruby behavior of BigDecimal changed in 2.4, this test is not valid on older rubies
@@ -293,12 +293,12 @@ describe ROXML::Definition do
         end
 
         it "should extract what it can" do
-          expect(@definition.blocks.first['11sttf']).to eql(BigDecimal.new("11.0"))
+          expect(@definition.blocks.first['11sttf']).to eql(BigDecimal("11.0"))
         end
 
         context "when passed an array" do
           it "should translate the array elements to integer" do
-            expect(@definition.blocks.first.call(["12.1", "328.2"])).to eq([BigDecimal.new("12.1"), BigDecimal.new("328.2")])
+            expect(@definition.blocks.first.call(["12.1", "328.2"])).to eq([BigDecimal("12.1"), BigDecimal("328.2")])
           end
         end
       end


### PR DESCRIPTION
After upgrading to ruby 2.6.1, our application started logging this warning:
```
warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```
which was being emitted from `roxml-4.0.0/lib/roxml/definition.rb:179`: https://github.com/Empact/roxml/blob/9c6e27c621ed8ff8f030c80fb30ad23333717045/lib/roxml/definition.rb#L179

So, in this PR I've replaced the deprecated `BigDecimal.new` invocations with invoking the `BigDecimal` method as recommended.