### PR TITLE
Remove ActiveSupport dependency 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem 'activesupport', '>= 4.0'
+gem "concurrent-ruby", "~> 1.1"
 gem 'nokogiri', '>= 1.3.3'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "http://rubygems.org"
 
 gem 'activesupport', '>= 4.0'
 gem "concurrent-ruby", "~> 1.1"
+gem "dry-core", "~> 0.4"
+gem "dry-inflector", "~> 0.1"
 gem 'nokogiri', '>= 1.3.3'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "http://rubygems.org"
 
-gem 'activesupport', '>= 4.0'
 gem "concurrent-ruby", "~> 1.1"
 gem "dry-core", "~> 0.4"
 gem "dry-inflector", "~> 0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,9 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
+    dry-core (0.4.8)
+      concurrent-ruby (~> 1.0)
+    dry-inflector (0.1.2)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     faraday (0.12.2)
@@ -94,6 +97,8 @@ DEPENDENCIES
   activerecord (>= 4.0)
   activesupport (>= 4.0)
   concurrent-ruby (~> 1.1)
+  dry-core (~> 0.4)
+  dry-inflector (~> 0.1)
   equivalent-xml (>= 0.6.0)
   juwelier
   minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (>= 4.0)
-  activesupport (>= 4.0)
   concurrent-ruby (~> 1.1)
   dry-core (~> 0.4)
   dry-inflector (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     builder (3.2.3)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
@@ -93,6 +93,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (>= 4.0)
   activesupport (>= 4.0)
+  concurrent-ruby (~> 1.1)
   equivalent-xml (>= 0.6.0)
   juwelier
   minitest

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ Juwelier::GemcutterTasks.new
 Dir['tasks/**/*.rake'].each { |t| load t }
 
 task :default => [:test, :spec]
-task :all => [:libxml, :nokogiri]
+task :all => [:libxml, :nokogiri, 'spec:active_record']
 task :libxml => ['test:libxml', 'spec:libxml']
 task :nokogiri => ['test:nokogiri', 'spec:nokogiri']
 
@@ -45,7 +45,7 @@ require 'rspec/core/rake_task'
 desc "Run specs"
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.ruby_opts = '-Ilib -Ispec -Iexamples'
-  # spec.spec_files = FileList['spec/**/*_spec.rb']
+  spec.exclude_pattern = "spec/examples/active_record*_spec.rb"
 end
 
 namespace :spec do
@@ -53,8 +53,14 @@ namespace :spec do
     desc "Spec ROXML under the #{parser} parser"
     RSpec::Core::RakeTask.new(parser) do |spec|
       spec.ruby_opts = '-Ilib -Ispec -Iexamples'
+      spec.exclude_pattern = "spec/examples/active_record*_spec.rb"
       # spec.spec_files = ["spec/support/#{parser}.rb"] + FileList['spec/**/*_spec.rb']
     end
+  end
+
+  desc "Spec ROXML under ActiveRecord"
+  RSpec::Core::RakeTask.new(:active_record) do |spec|
+    spec.pattern = "spec/examples/active_record*_spec.rb"
   end
 end
 

--- a/examples/amazon.rb
+++ b/examples/amazon.rb
@@ -6,7 +6,7 @@ require_relative './../spec/spec_helper'
 module PITA
   class Base
     include ROXML
-    xml_convention :camelcase
+    xml_convention :camelize
   end
 
   class Item < Base

--- a/examples/dashed_elements.rb
+++ b/examples/dashed_elements.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'date'
 require_relative './../spec/spec_helper'
 
 module GitHub

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -3,7 +3,6 @@ require 'uri'
 require 'active_support'
 if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3')
   require 'active_support/inflector'
-  require 'active_support/core_ext/object/duplicable'
   require 'active_support/core_ext/module/delegation'
   require 'active_support/core_ext/array/extract_options'
   require 'active_support/core_ext/hash'

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -1,9 +1,4 @@
 require 'uri'
-
-require 'active_support'
-if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3')
-  require 'active_support/inflector'
-end
 require 'dry/core/inflector'
 
 require 'roxml/definition'

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -26,7 +26,7 @@ module ROXML # :nodoc:
   module InstanceMethods # :nodoc:
     # Returns an XML object representing this object
     def to_xml(params = {})
-      params.reverse_merge!(:name => self.class.tag_name, :namespace => self.class.roxml_namespace)
+      params = {:name => self.class.tag_name, :namespace => self.class.roxml_namespace}.merge(params)
       params[:namespace] = nil if ['*', 'xmlns'].include?(params[:namespace])
       XML.new_node([params[:namespace], params[:name]].compact.join(':')).tap do |root|
         refs = (self.roxml_references \

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -4,7 +4,6 @@ require 'active_support'
 if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3')
   require 'active_support/inflector'
   require 'active_support/core_ext/hash'
-  require 'active_support/core_ext/string/starts_ends_with'
 end
 
 require 'roxml/definition'

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -29,7 +29,7 @@ module ROXML # :nodoc:
       params.reverse_merge!(:name => self.class.tag_name, :namespace => self.class.roxml_namespace)
       params[:namespace] = nil if ['*', 'xmlns'].include?(params[:namespace])
       XML.new_node([params[:namespace], params[:name]].compact.join(':')).tap do |root|
-        refs = (self.roxml_references.present? \
+        refs = (self.roxml_references \
           ? self.roxml_references \
           : self.class.roxml_attrs.map {|attr| attr.to_ref(self) })
         refs.each do |ref|

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -3,7 +3,6 @@ require 'uri'
 require 'active_support'
 if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3')
   require 'active_support/inflector'
-  require 'active_support/core_ext/hash'
 end
 
 require 'roxml/definition'

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -4,6 +4,7 @@ require 'active_support'
 if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3')
   require 'active_support/inflector'
 end
+require 'dry/core/inflector'
 
 require 'roxml/definition'
 require 'roxml/xml'
@@ -162,7 +163,12 @@ module ROXML # :nodoc:
         @roxml_naming_convention =
           if to_proc_able
             raise ArgumentError, "only one conventions can be set" if block_given?
-            to_proc_able.to_proc
+
+            if to_proc_able.is_a?(Symbol) && roxml_inflector.respond_to?(to_proc_able)
+              roxml_inflector.method(to_proc_able)
+            else
+              to_proc_able.to_proc
+            end
           elsif block_given?
             block
           end
@@ -171,6 +177,20 @@ module ROXML # :nodoc:
       def roxml_naming_convention # :nodoc:
         @roxml_naming_convention || begin
           superclass.roxml_naming_convention if superclass.respond_to?(:roxml_naming_convention)
+        end
+      end
+
+      def xml_inflector(inflector)
+        @roxml_inflector = inflector
+      end
+
+      def roxml_inflector
+        @roxml_inflector ||= begin
+          if superclass.respond_to?(:roxml_inflector) && superclass.roxml_inflector
+            superclass.roxml_inflector
+          else
+            Dry::Core::Inflector.inflector
+          end
         end
       end
 
@@ -497,7 +517,7 @@ module ROXML # :nodoc:
         return roxml_tag_name if roxml_tag_name
         
         if tag_name = name.split('::').last
-          roxml_naming_convention ? roxml_naming_convention.call(tag_name.underscore) : tag_name.downcase
+          roxml_naming_convention ? roxml_naming_convention.call(roxml_inflector.underscore(tag_name)) : tag_name.downcase
         end
       end
 

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -3,7 +3,6 @@ require 'uri'
 require 'active_support'
 if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3')
   require 'active_support/inflector'
-  require 'active_support/core_ext/array/extract_options'
   require 'active_support/core_ext/hash'
   require 'active_support/core_ext/string/starts_ends_with'
 end
@@ -442,8 +441,7 @@ module ROXML # :nodoc:
       # [:to_xml] this proc is applied to the attributes value outputting the instance via #to_xml
       # [:namespace] (false) disables or (string) overrides the default namespace declared with xml_namespace
       #
-      def xml_attr(*syms, &block)
-        opts = syms.extract_options!
+      def xml_attr(*syms, **opts, &block)
         syms.map do |sym|
           Definition.new(sym, opts, &block).tap do |attr|
             if roxml_attrs.map(&:accessor).include? attr.accessor

--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -3,7 +3,6 @@ require 'uri'
 require 'active_support'
 if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3')
   require 'active_support/inflector'
-  require 'active_support/core_ext/module/delegation'
   require 'active_support/core_ext/array/extract_options'
   require 'active_support/core_ext/hash'
   require 'active_support/core_ext/string/starts_ends_with'

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -106,7 +106,12 @@ module ROXML
         @default = [] if array?
         @default = {} if hash?
       end
-      @default.duplicable? ? @default.dup : @default
+
+      begin
+        @default.dup
+      rescue TypeError
+        @default
+      end
     end
 
     def to_ref(inst)

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -1,3 +1,4 @@
+require 'dry/core/inflector'
 require 'roxml/hash_definition'
 require 'roxml/utils'
 
@@ -16,7 +17,7 @@ module ROXML
   end
 
   class Definition # :nodoc:
-    attr_reader :name, :sought_type, :wrapper, :hash, :blocks, :accessor, :to_xml, :attr_name, :namespace
+    attr_reader :name, :sought_type, :wrapper, :hash, :blocks, :accessor, :to_xml, :attr_name, :namespace, :inflector
     bool_attr_reader :name_explicit, :array, :cdata, :required, :frozen
 
     def initialize(sym, opts = {}, &block)
@@ -28,6 +29,7 @@ module ROXML
       @frozen = opts.delete(:frozen)
       @wrapper = opts.delete(:in)
       @namespace = opts.delete(:namespace)
+      @inflector = opts.fetch(:inflector) { Dry::Core::Inflector.inflector }
 
       @accessor = sym.to_s
       opts[:as] ||=
@@ -63,7 +65,7 @@ module ROXML
       end
 
       @name = @attr_name = accessor.to_s.chomp('?')
-      @name = @name.singularize if hash? || array?
+      @name = inflector.singularize(@name) if hash? || array?
       @name = (opts[:from] || @name).to_s
       if hash? && (hash.key.name? || hash.value.name?)
         @name = '*'

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -32,11 +32,11 @@ module ROXML
 
       @accessor = sym.to_s
       opts[:as] ||=
-        if @accessor.ends_with?('?')
+        if @accessor.end_with?('?')
           :bool
-        elsif @accessor.ends_with?('_on')
+        elsif @accessor.end_with?('_on')
           Date
-        elsif @accessor.ends_with?('_at')
+        elsif @accessor.end_with?('_at')
           DateTime
         end
 
@@ -58,7 +58,7 @@ module ROXML
       elsif opts[:from] == :namespace
         opts[:from] = '*'
         @sought_type = :namespace
-      elsif opts[:from].to_s.starts_with?('@')
+      elsif opts[:from].to_s.start_with?('@')
         @sought_type = :attr
         opts[:from].sub!('@', '')
       end

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -178,23 +178,23 @@ module ROXML
       # dynamically load these shorthands at class definition time, but
       # only if they're already availbable
       CORE_BLOCK_SHORTHANDS.tap do |blocks|
-        blocks.reverse_merge!(BigDecimal => lambda do |val|
+        blocks[BigDecimal] = lambda do |val|
           all(val) do |v|
             BigDecimal(v) unless Utils.string_blank?(v.to_s)
           end
-        end) if defined?(BigDecimal)
+        end if defined?(BigDecimal)
 
-        blocks.reverse_merge!(DateTime => lambda do |val|
+        blocks[DateTime] = lambda do |val|
           if defined?(DateTime)
             all(val) {|v| DateTime.parse(v) unless Utils.string_blank?(v.to_s)}
           end
-        end) if defined?(DateTime)
+        end if defined?(DateTime)
 
-        blocks.reverse_merge!(Date => lambda do |val|
+        blocks[Date] = lambda do |val|
           if defined?(Date)
             all(val) {|v| Date.parse(v) unless Utils.string_blank?(v.to_s)}
           end
-        end) if defined?(Date)
+        end if defined?(Date)
       end
     end
 

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -1,4 +1,5 @@
 require 'roxml/hash_definition'
+require 'roxml/utils'
 
 class Module
   def bool_attr_reader(*attrs)
@@ -67,7 +68,7 @@ module ROXML
       if hash? && (hash.key.name? || hash.value.name?)
         @name = '*'
       end
-      raise ContradictoryNamespaces if @name.include?(':') && (@namespace.present? || @namespace == false)
+      raise ContradictoryNamespaces if @name.include?(':') && (@namespace || @namespace == false)
 
       raise ArgumentError, "Can't specify both :else default and :required" if required? && @default
     end
@@ -148,16 +149,16 @@ module ROXML
       # Core Shorthands
       Integer  => lambda do |val|
         all(val) do |v|
-          v.to_i unless v.blank?
+          v.to_i unless Utils.string_blank?(v.to_s)
         end
       end,
       Float    => lambda do |val|
         all(val) do |v|
-          Float(v) unless v.blank?
+          Float(v) unless Utils.string_blank?(v.to_s)
         end
       end,
       Time     => lambda do |val|
-        all(val) {|v| Time.parse(v) unless v.blank? }
+        all(val) {|v| Time.parse(v) unless Utils.string_blank?(v.to_s)}
       end,
 
       :bool    => nil,
@@ -179,19 +180,19 @@ module ROXML
       CORE_BLOCK_SHORTHANDS.tap do |blocks|
         blocks.reverse_merge!(BigDecimal => lambda do |val|
           all(val) do |v|
-            BigDecimal(v) unless v.blank?
+            BigDecimal(v) unless Utils.string_blank?(v.to_s)
           end
         end) if defined?(BigDecimal)
 
         blocks.reverse_merge!(DateTime => lambda do |val|
           if defined?(DateTime)
-            all(val) {|v| DateTime.parse(v) unless v.blank? }
+            all(val) {|v| DateTime.parse(v) unless Utils.string_blank?(v.to_s)}
           end
         end) if defined?(DateTime)
 
         blocks.reverse_merge!(Date => lambda do |val|
           if defined?(Date)
-            all(val) {|v| Date.parse(v) unless v.blank? }
+            all(val) {|v| Date.parse(v) unless Utils.string_blank?(v.to_s)}
           end
         end) if defined?(Date)
       end

--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -19,8 +19,6 @@ module ROXML
     bool_attr_reader :name_explicit, :array, :cdata, :required, :frozen
 
     def initialize(sym, opts = {}, &block)
-      opts.assert_valid_keys(:from, :in, :as, :namespace,
-                             :else, :required, :frozen, :cdata, :to_xml)
       @default = opts.delete(:else)
       @to_xml = opts.delete(:to_xml)
       @name_explicit = opts.has_key?(:from) && opts[:from].is_a?(String)

--- a/lib/roxml/hash_definition.rb
+++ b/lib/roxml/hash_definition.rb
@@ -4,8 +4,6 @@ module ROXML
     attr_accessor :wrapper
 
     def initialize(opts)
-      opts.assert_valid_keys(:key, :value)
-
       @key = Definition.new(nil, to_definition_options(opts, :key))
       @value = Definition.new(nil, to_definition_options(opts, :value))
     end

--- a/lib/roxml/utils.rb
+++ b/lib/roxml/utils.rb
@@ -1,0 +1,38 @@
+require 'concurrent/map'
+
+module ROXML
+  module Utils
+    module_function
+
+    # The following taken from active_support/core_ext/object/blank:
+
+    BLANK_RE = /\A[[:space:]]*\z/
+    ENCODED_BLANKS = Concurrent::Map.new do |h, enc|
+      h[enc] = Regexp.new(BLANK_RE.source.encode(enc), BLANK_RE.options | Regexp::FIXEDENCODING)
+    end
+
+    # A string is blank if it's empty or contains whitespaces only:
+    #
+    #   ''.blank?       # => true
+    #   '   '.blank?    # => true
+    #   "\t\n\r".blank? # => true
+    #   ' blah '.blank? # => false
+    #
+    # Unicode whitespace is supported:
+    #
+    #   "\u00a0".blank? # => true
+    #
+    # @return [true, false]
+    def string_blank?(string)
+      # The regexp that matches blank strings is expensive. For the case of empty
+      # strings we can speed up this method (~3.5x) with an empty? call. The
+      # penalty for the rest of strings is marginal.
+      string.empty? ||
+        begin
+          BLANK_RE.match?(string)
+        rescue Encoding::CompatibilityError
+          ENCODED_BLANKS[string.encoding].match?(string)
+        end
+    end
+  end
+end

--- a/lib/roxml/xml/parsers/libxml.rb
+++ b/lib/roxml/xml/parsers/libxml.rb
@@ -55,7 +55,7 @@ module ROXML
         if xml.namespaces.default
           roxml_namespaces = {:xmlns => namespaces.default.href}.merge(roxml_namespaces)
         end
-        if roxml_namespaces.present?
+        if roxml_namespaces.any?
           xml.find(xpath, roxml_namespaces.map {|prefix, href| [prefix, href].join(':') })
         else
           xml.find(xpath)

--- a/lib/roxml/xml/parsers/nokogiri.rb
+++ b/lib/roxml/xml/parsers/nokogiri.rb
@@ -58,7 +58,7 @@ module ROXML
           xml.search(xpath, roxml_namespaces)
         else
           xpath = "./#{xpath}"
-          (roxml_namespaces.present? ? xml.search(xpath, roxml_namespaces) : xml.search(xpath))
+          (roxml_namespaces.any? ? xml.search(xpath, roxml_namespaces) : xml.search(xpath))
         end
       end
     end

--- a/lib/roxml/xml/parsers/nokogiri.rb
+++ b/lib/roxml/xml/parsers/nokogiri.rb
@@ -33,7 +33,7 @@ module ROXML
       end
 
       def parse_file(path)
-        path = path.sub('file:', '') if path.starts_with?('file:')
+        path = path.sub('file:', '') if path.start_with?('file:')
         parse_io(open(path))
       end
 

--- a/lib/roxml/xml/references.rb
+++ b/lib/roxml/xml/references.rb
@@ -94,7 +94,7 @@ module ROXML
     end
 
     def auto_wrapper
-      namespacify(conventionize(opts.name.pluralize))
+      namespacify(conventionize(@instance.class.roxml_inflector.pluralize(opts.name)))
     end
 
     def auto_xpath

--- a/lib/roxml/xml/references.rb
+++ b/lib/roxml/xml/references.rb
@@ -1,3 +1,4 @@
+require "forwardable"
 require "rexml/xpath_parser"
 
 module ROXML
@@ -8,8 +9,10 @@ module ROXML
   # Internal base class that represents an XML - Class binding.
   #
   class XMLRef # :nodoc:
+    extend Forwardable
+
     attr_reader :opts
-    delegate :required?, :array?, :accessor, :default, :wrapper, :to => :opts
+    def_delegators :opts, :required?, :array?, :accessor, :default, :wrapper
 
     def initialize(opts, instance)
       @opts = opts
@@ -180,7 +183,7 @@ module ROXML
   #   XMLTextRef
   #  </element>
   class XMLTextRef < XMLRef # :nodoc:
-    delegate :cdata?, :content?, :name?, :to => :opts
+    def_delegators :opts, :cdata?, :content?, :name?
 
     # Updates the text in the given _xml_ block to
     # the _value_ provided.
@@ -240,7 +243,7 @@ module ROXML
   end
 
   class XMLHashRef < XMLTextRef # :nodoc:
-    delegate :hash, :to => :opts
+    def_delegators :opts, :hash
 
     def initialize(opts, inst)
       super(opts, inst)
@@ -298,7 +301,7 @@ module ROXML
   end
 
   class XMLObjectRef < XMLTextRef # :nodoc:
-    delegate :sought_type, :to => :opts
+    def_delegators :opts, :sought_type
 
     # Updates the composed XML object in the given XML block to
     # the value provided.

--- a/roxml.gemspec
+++ b/roxml.gemspec
@@ -140,7 +140,6 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activesupport>.freeze, [">= 4.0"])
       s.add_runtime_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
       s.add_runtime_dependency(%q<dry-core>.freeze, ["~> 0.4"])
       s.add_runtime_dependency(%q<dry-inflector>.freeze, ["~> 0.1"])
@@ -154,7 +153,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rack>.freeze, ["< 2.0.0"])
       s.add_development_dependency(%q<equivalent-xml>.freeze, [">= 0.6.0"])
     else
-      s.add_dependency(%q<activesupport>.freeze, [">= 4.0"])
       s.add_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
       s.add_dependency(%q<dry-core>.freeze, ["~> 0.4"])
       s.add_dependency(%q<dry-inflector>.freeze, ["~> 0.1"])
@@ -169,7 +167,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<equivalent-xml>.freeze, [">= 0.6.0"])
     end
   else
-    s.add_dependency(%q<activesupport>.freeze, [">= 4.0"])
     s.add_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
     s.add_dependency(%q<dry-core>.freeze, ["~> 0.4"])
     s.add_dependency(%q<dry-inflector>.freeze, ["~> 0.1"])

--- a/roxml.gemspec
+++ b/roxml.gemspec
@@ -141,6 +141,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activesupport>.freeze, [">= 4.0"])
+      s.add_runtime_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
       s.add_runtime_dependency(%q<nokogiri>.freeze, [">= 1.3.3"])
       s.add_development_dependency(%q<rake>.freeze, ["~> 0.9"])
       s.add_development_dependency(%q<juwelier>.freeze, [">= 0"])
@@ -152,6 +153,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<equivalent-xml>.freeze, [">= 0.6.0"])
     else
       s.add_dependency(%q<activesupport>.freeze, [">= 4.0"])
+      s.add_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
       s.add_dependency(%q<nokogiri>.freeze, [">= 1.3.3"])
       s.add_dependency(%q<rake>.freeze, ["~> 0.9"])
       s.add_dependency(%q<juwelier>.freeze, [">= 0"])
@@ -164,6 +166,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<activesupport>.freeze, [">= 4.0"])
+    s.add_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
     s.add_dependency(%q<nokogiri>.freeze, [">= 1.3.3"])
     s.add_dependency(%q<rake>.freeze, ["~> 0.9"])
     s.add_dependency(%q<juwelier>.freeze, [">= 0"])

--- a/roxml.gemspec
+++ b/roxml.gemspec
@@ -142,6 +142,8 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activesupport>.freeze, [">= 4.0"])
       s.add_runtime_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
+      s.add_runtime_dependency(%q<dry-core>.freeze, ["~> 0.4"])
+      s.add_runtime_dependency(%q<dry-inflector>.freeze, ["~> 0.1"])
       s.add_runtime_dependency(%q<nokogiri>.freeze, [">= 1.3.3"])
       s.add_development_dependency(%q<rake>.freeze, ["~> 0.9"])
       s.add_development_dependency(%q<juwelier>.freeze, [">= 0"])
@@ -154,6 +156,8 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<activesupport>.freeze, [">= 4.0"])
       s.add_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
+      s.add_dependency(%q<dry-core>.freeze, ["~> 0.4"])
+      s.add_dependency(%q<dry-inflector>.freeze, ["~> 0.1"])
       s.add_dependency(%q<nokogiri>.freeze, [">= 1.3.3"])
       s.add_dependency(%q<rake>.freeze, ["~> 0.9"])
       s.add_dependency(%q<juwelier>.freeze, [">= 0"])
@@ -167,6 +171,8 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<activesupport>.freeze, [">= 4.0"])
     s.add_dependency(%q<concurrent-ruby>.freeze, ["~> 1.1"])
+    s.add_dependency(%q<dry-core>.freeze, ["~> 0.4"])
+    s.add_dependency(%q<dry-inflector>.freeze, ["~> 0.1"])
     s.add_dependency(%q<nokogiri>.freeze, [">= 1.3.3"])
     s.add_dependency(%q<rake>.freeze, ["~> 0.9"])
     s.add_dependency(%q<juwelier>.freeze, [">= 0"])

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require 'bigdecimal'
+require 'date'
 require_relative './spec_helper'
 
 describe ROXML::Definition do

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -292,8 +292,10 @@ describe ROXML::Definition do
           end
         end
 
-        it "should extract what it can" do
-          expect(@definition.blocks.first['11sttf']).to eql(BigDecimal("11.0"))
+        if RUBY_VERSION < "2.6"
+          it "should extract what it can" do
+            expect(@definition.blocks.first['11sttf']).to eql(BigDecimal("11.0"))
+          end
         end
 
         context "when passed an array" do

--- a/spec/examples/post_spec.rb
+++ b/spec/examples/post_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'date'
 require_relative './../../examples/posts'
 
 describe Post do

--- a/spec/roxml_spec.rb
+++ b/spec/roxml_spec.rb
@@ -302,7 +302,7 @@ describe ROXML, "inheritance" do
     end
 
     def normalize_hundredths
-      if @units.starts_with? 'hundredths-'
+      if @units.start_with? 'hundredths-'
         @value /= 100
         @units = @units.split('hundredths-')[1]
       end

--- a/test/mocks/mocks.rb
+++ b/test/mocks/mocks.rb
@@ -93,7 +93,7 @@ private
   end
 
   def normalize_hundredths
-    if @units.starts_with? 'hundredths-'
+    if @units.start_with? 'hundredths-'
       @value /= 100
       @units = @units.split('hundredths-')[1]
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'rubygems'
+require 'roxml/utils'
 require_relative './mocks/mocks'
 require_relative './mocks/dictionaries'
 require_relative './support/fixtures'
@@ -23,7 +24,7 @@ def remove_children(xml)
   xml = ROXML::XML.parse_string(xml).root if xml.is_a?(String)
   return unless xml.respond_to? :children
   xml.children.each do |child|
-    if child.to_s.blank?
+    if ROXML::Utils.string_blank?(child.to_s)
       defined?(Nokogiri) ? child.remove : child.remove!
     else
       remove_children(child)

--- a/test/unit/definition_test.rb
+++ b/test/unit/definition_test.rb
@@ -1,3 +1,5 @@
+require 'date'
+require 'time'
 require_relative './../test_helper'
 require 'minitest/autorun'
 

--- a/test/unit/xml_convention_test.rb
+++ b/test/unit/xml_convention_test.rb
@@ -59,7 +59,7 @@ class BookCase
 end
 
 class BookCaseCamelCase < BookCase
-  xml_convention :camelcase
+  xml_convention :camelize
 end
 
 class BookCaseUnderScore < BookCase
@@ -106,7 +106,7 @@ class TestXMLConvention < Minitest::Test
   [BookCaseUpCase, BookCaseCamelLower, BookCaseDashes, BookCaseUnderScore, BookCaseCamelCase].each do |klass|
     define_method(:"test_xml_convention_#{klass.to_s.underscore}") do
       data = :"XML_#{klass.to_s.sub('BookCase', '').upcase}"
-      assert_equal Proc, klass.roxml_naming_convention.class
+      assert Proc, klass.roxml_naming_convention.respond_to?(:call)
 
       bc = klass.from_xml(Object.const_get(data))
       assert_has_book_case_info(bc)
@@ -116,7 +116,7 @@ class TestXMLConvention < Minitest::Test
   def test_child_should_inherit_convention_if_it_doesnt_declare_one
     [InheritedBookCaseUpCase, InheritedBookCaseCamelCase].each do |klass|
       data = :"XML_#{klass.to_s.sub('InheritedBookCase', '').upcase}"
-      assert_equal Proc, klass.roxml_naming_convention.class
+      assert klass.roxml_naming_convention.respond_to?(:call)
 
       bc = klass.from_xml(Object.const_get(data))
       assert_has_book_case_info(bc)

--- a/test/unit/xml_name_test.rb
+++ b/test/unit/xml_name_test.rb
@@ -133,7 +133,7 @@ end
 module WrapModule
   class BaseClass
     include ROXML
-    xml_convention :camelcase
+    xml_convention :camelize
   end
 
   class InstanceStandin < BaseClass


### PR DESCRIPTION
Hi there! 👋 

I've been resuscitating another old gem that relies on roxml, and I wanted to be able to run it without introducing ActiveSupport and its patching of various Ruby core classes.

So in this PR, I've removed all usages of ActiveSupport core classes extensions from within roxml.

I know you opened up https://github.com/Empact/roxml/issues/8 back in 2009(!) and decided in the end to leave ActiveSupport in place, because "it will then be a reliable base library," but IMHO, this didn't quite work out as expected, e.g. you can't even use the ActiveSupport inflector standalone without bringing in its various patches on String, etc. From my perspective, an ideal Ruby library today shouldn't change core class behaviour if it can easily avoid it (particularly if that library supports usage outside of Rails – or even by other libraries, which is the case for me) so I hope you will be open to reconsidering this in 2019! :)

I've made a commit for each specific group of changes, so hopefully the history here is easy to follow.

The biggest of all the adjustments I made (in terms of roxml's actual API) is the introduction of `xml_inflector` (in https://github.com/Empact/roxml/commit/ae34e42302a4eb56b203c41e169e289d15713c43), for providing a user-configurable inflector object. For this I rely on `Dry::Core::Inflector`, which will detect an appropriate inflector backend based on the currently available gems. If ActiveSupport is available, it will use its inflector first, so there should be no change in actual behaviour for your existing users. And unlike activesupport, dry-core is a very small and minimal-impact dependency.

Apart from this, the only other thing of note is that to preserve some meaningful behaviour from ActiveSupport's `String#blank?` patch, I copied the implementation into `ROXML::Utils.string_blank?` and used that where appropriate, which seemed like a reasonable approach to maintain feature compatibility.

Thanks for taking a look at this, and please let me know if there's any more I can do! I appreciate all you've done to keep a gem like this maintained over all the years ❤️ 