### PR TITLE
spec/definition_sec.rb: remove BigDecimal test not supported by Ruby 2.7

### DIFF
--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -292,10 +292,6 @@ describe ROXML::Definition do
           end
         end
 
-        it "should extract what it can" do
-          expect(@definition.blocks.first['11sttf']).to eql(BigDecimal("11.0"))
-        end
-
         context "when passed an array" do
           it "should translate the array elements to integer" do
             expect(@definition.blocks.first.call(["12.1", "328.2"])).to eq([BigDecimal("12.1"), BigDecimal("328.2")])


### PR DESCRIPTION
The latest version of BigDecimal does not accept characters as input of
BigDecimal():

$ irb2.5
irb(main):001:0> require 'bigdecimal'
=> true
irb(main):002:0> BigDecimal("11sttf")
=> 0.11e2

$ irb2.7
irb(main):001:0> require 'bigdecimal'
=> true
irb(main):002:0> BigDecimal("11sttf")
Traceback (most recent call last):
        5: from /usr/bin/irb2.7:23:in `<main>'
        4: from /usr/bin/irb2.7:23:in `load'
        3: from /usr/lib/ruby/gems/2.7.0/gems/irb-1.2.1/exe/irb:11:in `<top (required)>'
        2: from (irb):2
        1: from (irb):2:in `BigDecimal'
ArgumentError (invalid value for BigDecimal(): "11sttf")