### PR TITLE
Fix issue with 'from' clause and frozen_string_literal magic comment

### DIFF
--- a/lib/roxml/definition.rb
+++ b/lib/roxml/definition.rb
@@ -60,7 +60,7 @@ module ROXML
         @sought_type = :namespace
       elsif opts[:from].to_s.starts_with?('@')
         @sought_type = :attr
-        opts[:from].sub!('@', '')
+        opts[:from] = opts[:from].sub('@', '')
       end
 
       @name = @attr_name = accessor.to_s.chomp('?')

--- a/spec/definition_spec.rb
+++ b/spec/definition_spec.rb
@@ -426,7 +426,6 @@ describe ROXML::Definition do
   end
 
   describe "options" do
-
     shared_examples_for "boolean option" do
       it "should be recognized" do
         ROXML::Definition.new(:author, :from => :content, @option => true).respond_to?(:"#{@option}?")
@@ -466,6 +465,12 @@ describe ROXML::Definition do
       end
 
       it_should_behave_like "boolean option"
+    end
+  end
+
+  describe 'frozen_string_literal behavior' do
+    it 'should not raise error' do
+      expect { ROXML::Definition.new(:element, :from => '@somewhere'.freeze) }.not_to raise_error(FrozenError)
     end
   end
 end


### PR DESCRIPTION
I suggest a fix for situation when adding magic comment frozen_string_literal to file with ROXML definition

```ruby
  # frozen_string_literal: true

  class Book
    include ROXML

    xml_reader :isbn, from: '@isbn'
  end
```

having this, you'll get the following error during serialization:
```
FrozenError: can't modify frozen String: "@isbn"
from /Users/khataev/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/roxml-4.1.0/lib/roxml/definition.rb:63:in `sub!'
```

fix is simple, replacing bang version of sub! with safe version