### PR TITLE
use URI::DEFAULT_PARSER to get rid of deprecation warning

### DIFF
--- a/lib/roxml/xml/references.rb
+++ b/lib/roxml/xml/references.rb
@@ -47,7 +47,7 @@ module ROXML
     def conventionize(what)
       convention ||= @instance.class.respond_to?(:roxml_naming_convention) && @instance.class.roxml_naming_convention
       if !what.blank? && convention.respond_to?(:call)
-        URI.unescape(convention.call(URI.escape(what, /\/|::/)))
+        URI::DEFAULT_PARSER.unescape(convention.call(URI::DEFAULT_PARSER.escape(what, /\/|::/)))
       else
         what
       end


### PR DESCRIPTION
This feels like a bit of a hack to get rid of the deprecation warning but seemed to be the simplest way. From what I can tell, `URI.escape` and `URI.unescape` have been deprecated because they shouldn't be used to escape actual URIs. In this case though we aren't using them to escape URIs and none of the recommended replacements (`CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component`) allow only escaping specific characters which is the behavior we want.

I didn't add a spec because this is doesn't meaningfully change the code (`URI.escape`/`URI.unescape` already delegate to `URI::DEFAULT_PARSER`) and `test_xml_name_not_screwed_up_by_xml_convention` already tests this behavior.

Fixes #71 